### PR TITLE
fix: add force flag to npm ci command

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
-      - run: npm ci
+      - run: npm ci --force
       - run: npm audit fix --force
       - run: npm run build --if-present
       - run: npm run lint


### PR DESCRIPTION
"force" flag was added to ensure many dependency versions could co-exist in the modules after building.