### PR TITLE
chore: replace 3G78.dbn example

### DIFF
--- a/src/assets/examples/secondary/3G78.dbn
+++ b/src/assets/examples/secondary/3G78.dbn
@@ -1,6 +1,6 @@
 >strand_A
 GuGUGCCCGGCAUGGGUGCAGUCUAUAGGGUGAGAGUCCCGAACUGUGAAGGCAGAAGUAACAGUUAGCCUAACGCAAGGGUGUCCGUGGCGACAUGGAAUCUGAAGGAAGCGGACGGCAAACCUUCGGUCUGAGGAACACGAACUUCAUAUGAGGCUAGGUAUCAAUGGAUGAGUUUGCAUAACAAAACAAAGUCCUUUCUGCCAAAGUUGGUACAGAGUAAAUGAAGCAGAUUGAUGAAGGGAAAGACUGCAUUCUUACCCGGGGAGGUCUGGAAACAGAAGUCAGCAGAAGUCAUAGUACCCUGUUCGCAGGGGAAGGACGGAACAAGUAUGGCGUUCGCGCCUAAGCUUGAACCGCCGUAUACCGAACGGUACGUACGGUGGUGUGAGAGGAGUUCGCUCUACUCUAU
--.{[.(((((<..(((((((((((...(((.......)))..(((((...{{{.{{{...)))))..(((...(((..((((.((((((....))))))))))...]>..)))...)))...(((((((((((.(.....)...(((((.....[((...((((.(((((((..((((.][[[[[.))))...)))).}}}.}}}...))).))))...))...))))))))))...))))))...)))))))))))...})))))(...((((....))))...).......(((.(....(((........)))...))))....(((((..((((....))))...))))).(((((((((((((....)))..))))))))))...----------------------
+-.[{.(((((<..(((((((((((...(((.......)))..(((((...[[[.[[[...)))))..(((...(((..((((.((((((....))))))))))...}>..)))...)))...(((((((((((.(.....)...(((((.....[((...((((.(((((((..((((.]{{{{{.))))...)))).]]].]]]...))).))))...))...))))))))))...))))))...)))))))))))...])))))(...((((....))))...).......(((.(....((..........))...))))....(((((..((((....))))...))))).(((((((((((((....)))..))))))))))...----------------------
 >strand_Z
 uGUUAUUUU
-.]]]]]...
+.}}}}}...


### PR DESCRIPTION
Replaced example 3G78.dbn to the one received through analysis of 3G78.ct example.